### PR TITLE
Define module version to enable automatic releasing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cloud-plugin-hypervisor-xenserver</artifactId>
   <name>Cosmic Plugin - Hypervisor XenServer</name>
+  <version>5.0.0.1-SNAPSHOT</version>
   <parent>
     <groupId>cloud.cosmic</groupId>
     <artifactId>cosmic</artifactId>


### PR DESCRIPTION
In order to automate releases we need to bump the parent version independently form the version of the modules. Therefore, the modules cannot inherit the version of the parent.

This PR defines the version of the module.
