### PR TITLE
Revert "Add dependency managment."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,23 +3,11 @@
   <artifactId>cloud-plugin-hypervisor-xenserver</artifactId>
   <name>Cosmic Plugin - Hypervisor XenServer</name>
   <version>5.1.0.0-SNAPSHOT</version>
-
   <parent>
     <groupId>cloud.cosmic</groupId>
     <artifactId>cosmic</artifactId>
     <version>5.1.0.0-SNAPSHOT</version>
   </parent>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>net.java.dev.vcc.thirdparty</groupId>
-        <artifactId>xen-api</artifactId>
-        <version>6.2.0-3.1</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>cloud.cosmic</groupId>


### PR DESCRIPTION
This reverts commit 92ec4b85fd5eaa23570e1dbb23e32fc066251fbb.

Dependencies are now being managed by the parent pom.
